### PR TITLE
feat: immersive chatbot dialog + mobile drawer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -89,6 +89,14 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* The <body> is the centered layout container (mx-auto w-[min(95%,750px)]).
+     Radix's scroll-lock sets margin-left:0 and margin-right:15px on body,
+     which destroys mx-auto and pushes the page to the left edge. Restore
+     auto margins while the lock is active so the layout stays centered. */
+  html body[data-scroll-locked] {
+    margin-left: auto !important;
+    margin-right: auto !important;
+  }
 }
 
 .chat-markdown p { margin: 0.25em 0; }

--- a/components/chat-bot.tsx
+++ b/components/chat-bot.tsx
@@ -3,8 +3,17 @@
 import React from "react";
 import { useChat } from "@ai-sdk/react";
 import { ScrollArea } from "./ui/scroll-area";
-import { User, ChevronDown, Send } from "lucide-react";
+import { User, Send, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerClose,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import {
   PromptInput,
   PromptInputBody,
@@ -23,6 +32,12 @@ import Image from "next/image";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+const AI_AVATAR_SRC =
+  "https://www.gstatic.com/lamda/images/sparkle_resting_v2_darkmode_2bdb7df2724e450073ede.gif";
+
+const DIALOG_DESCRIPTION =
+  "Chat with an AI about Marcos's experience, projects, and availability.";
 
 const SUGGESTIONS = [
   {
@@ -72,7 +87,8 @@ const SUGGESTIONS = [
 const ChatBot = () => {
   const bottomRef = React.useRef<HTMLDivElement | null>(null);
   const inputWrapperRef = React.useRef<HTMLDivElement | null>(null);
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const { messages, status, sendMessage, stop } = useChat({
     onError: () => {
@@ -86,15 +102,14 @@ const ChatBot = () => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // Auto-expand when there are messages
   React.useEffect(() => {
     if (messages.length > 0) {
-      setIsExpanded(true);
+      setIsOpen(true);
     }
   }, [messages.length]);
 
   const handleSubmit = ({ text }: PromptInputMessage) => {
-    if (!text.trim() || isLoading) return;
+    if (!text?.trim() || isLoading) return;
     sendMessage({
       role: "user",
       parts: [{ type: "text", text }],
@@ -103,31 +118,17 @@ const ChatBot = () => {
 
   const handleSuggestion = (suggestion: string) => {
     if (isLoading) return;
-    setIsExpanded(true);
-    const textarea = inputWrapperRef.current?.querySelector("textarea");
-    if (!textarea) return;
-    textarea.value = suggestion;
-    textarea.dispatchEvent(new Event("input", { bubbles: true }));
-    textarea.focus();
+    setIsOpen(true);
+    // Wait for the dialog/drawer to mount before reaching into the textarea.
+    setTimeout(() => {
+      const textarea = inputWrapperRef.current?.querySelector("textarea");
+      if (!textarea) return;
+      textarea.value = suggestion;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea.focus();
+    }, 120);
   };
 
-  const handleExpand = () => {
-    if (!isExpanded) {
-      setIsExpanded(true);
-      // Focus the textarea after expansion
-      setTimeout(() => {
-        const textarea = inputWrapperRef.current?.querySelector("textarea");
-        textarea?.focus();
-      }, 100);
-    }
-  };
-
-  const handleCollapse = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsExpanded(false);
-  };
-
-  // Helper to extract text content from message parts
   const getMessageText = (message: (typeof messages)[0]): string => {
     if (Array.isArray(message.parts)) {
       return message.parts
@@ -141,188 +142,257 @@ const ChatBot = () => {
     return "";
   };
 
-  return (
-    <div className="relative mx-auto w-[min(95%,650px)] after:pointer-events-none after:absolute after:inset-px after:rounded-2xl after:shadow-highlight after:shadow-gray-300/20 after:transition-colors">
-      <section
-        className={cn(
-          "flex flex-col rounded-2xl border border-white/10 bg-background/60 backdrop-blur-md transition-all duration-300 ease-out",
-          isExpanded ? "gap-3 p-4" : "p-0"
-        )}
-      >
-        {/* Collapsed View */}
-        {!isExpanded && (
+  const handleOpenCollapsed = () => setIsOpen(true);
+  const handleKeyDownCollapsed = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setIsOpen(true);
+    }
+  };
+
+  const messagesList = (
+    <>
+      {messages.map((message) => {
+        const content = getMessageText(message);
+        const isUser = message.role === "user";
+
+        return (
           <div
-            onClick={handleExpand}
-            className="flex cursor-pointer items-center gap-2 px-3 py-2 transition-colors hover:bg-white/5 rounded-2xl"
+            key={message.id}
+            className={cn(
+              "mb-3 flex flex-col gap-1",
+              isUser ? "items-end" : "w-fit items-start",
+            )}
           >
-            <input
-              type="text"
-              readOnly
-              placeholder="Ask me anything..."
-              className="flex-1 bg-transparent text-sm text-muted-foreground placeholder:text-muted-foreground outline-none cursor-pointer"
-            />
-            <button
-              type="button"
-              className="flex h-8 w-8 items-center justify-center rounded-xl bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80"
-            >
-              <Send className="h-4 w-4" />
-            </button>
-          </div>
-        )}
-
-        {/* Expanded View */}
-        {isExpanded && (
-          <>
-            {/* Collapse Button */}
-            <div className="flex justify-end">
-              <button
-                onClick={handleCollapse}
-                className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/10 hover:text-white"
-                aria-label="Collapse chat"
-              >
-                <ChevronDown className="h-4 w-4" />
-              </button>
-            </div>
-
-            {/* Messages Area */}
-            <div
+            {isUser ? (
+              <div className="flex select-none items-center gap-1 text-sm text-muted-foreground">
+                <User strokeWidth="1.5" className="aspect-square w-5" />
+                <span>You</span>
+              </div>
+            ) : (
+              <div className="flex select-none items-center gap-1 text-sm text-white">
+                <Image
+                  src={AI_AVATAR_SRC}
+                  alt="AI gif"
+                  width={22}
+                  height={22}
+                />
+                <span>AI Chatbot</span>
+              </div>
+            )}
+            <ScrollArea
               className={cn(
-                "overflow-hidden transition-all duration-300 ease-out",
-                messages.length > 0
-                  ? "max-h-[200px] opacity-100"
-                  : "max-h-0 opacity-0"
+                "flex max-h-32 flex-col gap-1 rounded-lg border",
+                isUser
+                  ? "mr-6 rounded-tr-[3px] border-primary/30 bg-primary/15"
+                  : "ml-6 rounded-tl-[3px] border-secondary/50 bg-secondary/40",
               )}
             >
-              <ScrollArea className="h-[180px] w-full px-1 py-1">
-                {messages.map((message) => {
-                  const content = getMessageText(message);
-                  const isUser = message.role === "user";
+              {isUser ? (
+                <p className="rounded-none px-4 py-2 text-xs md:text-sm text-white">
+                  {content}
+                </p>
+              ) : (
+                <div className="chat-markdown rounded-none px-4 py-2 text-xs md:text-sm text-muted-foreground">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {content}
+                  </ReactMarkdown>
+                </div>
+              )}
+            </ScrollArea>
+          </div>
+        );
+      })}
+      {isLoading && messages[messages.length - 1]?.role === "user" && (
+        <div className="flex items-center gap-1 pb-4 text-sm">
+          <Image src={AI_AVATAR_SRC} alt="AI gif" width={22} height={22} />
+          <span className="animate-pulse text-xs text-muted-foreground">
+            generating...
+          </span>
+        </div>
+      )}
+      <div ref={bottomRef} />
+    </>
+  );
 
-                  return (
-                    <div
-                      key={message.id}
-                      className={cn(
-                        "mb-3 flex flex-col gap-1",
-                        isUser ? "items-end" : "w-fit items-start"
-                      )}
-                    >
-                      {isUser ? (
-                        <div className="flex select-none items-center gap-1 text-sm text-muted-foreground">
-                          <User strokeWidth="1.5" className="aspect-square w-5" />
-                          <span>You</span>
-                        </div>
-                      ) : (
-                        <div className="flex select-none items-center gap-1 text-sm text-white">
-                          <Image
-                            src="https://www.gstatic.com/lamda/images/sparkle_resting_v2_darkmode_2bdb7df2724e450073ede.gif"
-                            alt="AI gif"
-                            width={22}
-                            height={22}
-                          />
-                          <span>AI Chatbot</span>
-                        </div>
-                      )}
-                      <ScrollArea
-                        className={cn(
-                          "flex max-h-32 flex-col gap-1 rounded-lg border",
-                          isUser
-                            ? "mr-6 rounded-tr-[3px] border-primary/30 bg-primary/15"
-                            : "ml-6 rounded-tl-[3px] border-secondary/50 bg-secondary/40"
-                        )}
-                      >
-                        {isUser ? (
-                          <p className={cn(
-                            "rounded-none px-4 py-2 text-xs md:text-sm text-white"
-                          )}>
-                            {content}
-                          </p>
-                        ) : (
-                          <div className="chat-markdown rounded-none px-4 py-2 text-xs md:text-sm text-muted-foreground">
-                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                              {content}
-                            </ReactMarkdown>
-                          </div>
-                        )}
-                      </ScrollArea>
-                    </div>
-                  );
-                })}
-                {isLoading && messages[messages.length - 1]?.role === "user" && (
-                  <div className="flex items-center gap-1 pb-4 text-sm">
-                    <Image
-                      src="https://www.gstatic.com/lamda/images/sparkle_resting_v2_darkmode_2bdb7df2724e450073ede.gif"
-                      alt="AI gif"
-                      width={22}
-                      height={22}
-                    />
-                    <span className="animate-pulse text-xs text-muted-foreground">
-                      generating...
-                    </span>
-                  </div>
-                )}
-                <div ref={bottomRef} />
+  const suggestionsCarousel = (
+    <Carousel opts={{ align: "start", dragFree: true }} className="w-full">
+      <CarouselContent className="-ml-2">
+        {SUGGESTIONS.map((s) => (
+          <CarouselItem key={s.text} className="basis-auto pl-2">
+            <Suggestion
+              suggestion={s.text}
+              icon={s.icon}
+              gradientColor={s.gradientColor}
+              onClick={handleSuggestion}
+              disabled={isLoading}
+              className={s.className}
+            />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+    </Carousel>
+  );
+
+  const inputArea = (
+    <div ref={inputWrapperRef} className="relative w-full">
+      <PromptInput
+        onSubmit={handleSubmit}
+        className="w-full border-white/10 bg-secondary/30 transition-all duration-200 focus-within:border-white/25 focus-within:bg-secondary/40 focus-within:ring-1 focus-within:ring-white/10"
+      >
+        <PromptInputBody>
+          <PromptInputTextarea
+            placeholder="Pick a suggestion or ask anything about me..."
+            disabled={isLoading}
+            maxLength={160}
+            minLength={3}
+            className="text-xs text-white placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0 md:text-sm"
+          />
+        </PromptInputBody>
+        <PromptInputFooter className="justify-end">
+          <PromptInputTools>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex h-8 w-8 items-center justify-center rounded-xl bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:opacity-50"
+            >
+              {isLoading ? (
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-secondary-foreground border-t-transparent" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </button>
+          </PromptInputTools>
+        </PromptInputFooter>
+      </PromptInput>
+    </div>
+  );
+
+  return (
+    <div className="relative mx-auto w-[min(95%,650px)] after:pointer-events-none after:absolute after:inset-px after:rounded-2xl after:shadow-highlight after:shadow-gray-300/20 after:transition-colors">
+      <section className="flex flex-col rounded-2xl border border-white/10 bg-background/60 p-0 backdrop-blur-md transition-all duration-300 ease-out">
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={handleOpenCollapsed}
+          onKeyDown={handleKeyDownCollapsed}
+          className="flex cursor-pointer items-center gap-2 rounded-2xl px-3 py-2 transition-colors hover:bg-white/5"
+        >
+          <input
+            type="text"
+            readOnly
+            tabIndex={-1}
+            placeholder="Ask me anything..."
+            className="flex-1 cursor-pointer bg-transparent text-sm text-muted-foreground placeholder:text-muted-foreground outline-none"
+          />
+          <span
+            aria-hidden
+            className="flex h-8 w-8 items-center justify-center rounded-xl bg-secondary text-secondary-foreground transition-colors"
+          >
+            <Send className="h-4 w-4" />
+          </span>
+        </div>
+      </section>
+
+      {isDesktop ? (
+        <DialogPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
+          <DialogPrimitive.Portal>
+            <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
+            <DialogPrimitive.Content
+              onPointerDownOutside={(e) => e.preventDefault()}
+              className={cn(
+                "fixed left-1/2 top-1/2 z-50 flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden",
+                "h-[85vh] w-[min(90vw,900px)] rounded-2xl",
+                "border border-white/10 bg-background/95 shadow-2xl backdrop-blur-md",
+                "duration-300",
+                "data-[state=open]:animate-in data-[state=closed]:animate-out",
+                "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+                "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+                "data-[state=open]:slide-in-from-bottom-4 data-[state=closed]:slide-out-to-bottom-4",
+              )}
+            >
+              <header className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+                <div className="flex items-center gap-1.5 text-sm text-white">
+                  <Image
+                    src={AI_AVATAR_SRC}
+                    alt="AI gif"
+                    width={22}
+                    height={22}
+                  />
+                  <DialogPrimitive.Title className="text-sm font-normal leading-none tracking-normal text-white">
+                    AI Chatbot
+                  </DialogPrimitive.Title>
+                </div>
+                <DialogPrimitive.Description className="sr-only">
+                  {DIALOG_DESCRIPTION}
+                </DialogPrimitive.Description>
+                <DialogPrimitive.Close
+                  aria-label="Close chat"
+                  className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
+                >
+                  <X className="h-4 w-4" />
+                </DialogPrimitive.Close>
+              </header>
+
+              <div className="flex min-h-0 flex-1 flex-col px-4 pt-3">
+                <ScrollArea className="h-full w-full pr-2">
+                  {messagesList}
+                </ScrollArea>
+              </div>
+
+              <div className="flex flex-col gap-3 border-t border-white/10 p-4">
+                {suggestionsCarousel}
+                {inputArea}
+              </div>
+            </DialogPrimitive.Content>
+          </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
+      ) : (
+        <Drawer
+          open={isOpen}
+          onOpenChange={setIsOpen}
+          shouldScaleBackground={false}
+        >
+          <DrawerContent
+            onPointerDownOutside={(e) => e.preventDefault()}
+            className="flex h-[90vh] flex-col border-white/10 bg-background/95 backdrop-blur-md"
+          >
+            <div className="mt-2 flex flex-row items-center justify-between border-b border-white/10 px-4 py-3">
+              <div className="flex items-center gap-1.5 text-sm text-white">
+                <Image
+                  src={AI_AVATAR_SRC}
+                  alt="AI gif"
+                  width={22}
+                  height={22}
+                />
+                <DrawerTitle className="text-sm font-normal leading-none tracking-normal text-white">
+                  AI Chatbot
+                </DrawerTitle>
+              </div>
+              <DrawerDescription className="sr-only">
+                {DIALOG_DESCRIPTION}
+              </DrawerDescription>
+              <DrawerClose
+                aria-label="Close chat"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
+              >
+                <X className="h-4 w-4" />
+              </DrawerClose>
+            </div>
+
+            <div className="flex min-h-0 flex-1 flex-col px-4 pt-3">
+              <ScrollArea className="h-full w-full pr-2">
+                {messagesList}
               </ScrollArea>
             </div>
 
-            {/* Suggestions */}
-            <Carousel
-              opts={{ align: "start", dragFree: true }}
-              className="w-full"
-            >
-              <CarouselContent className="-ml-2">
-                {SUGGESTIONS.map((s) => (
-                  <CarouselItem key={s.text} className="basis-auto pl-2">
-                    <Suggestion
-                      suggestion={s.text}
-                      icon={s.icon}
-                      gradientColor={s.gradientColor}
-                      onClick={handleSuggestion}
-                      disabled={isLoading}
-                      className={s.className}
-                    />
-                  </CarouselItem>
-                ))}
-              </CarouselContent>
-            </Carousel>
-
-            {/* Input Area */}
-            <div
-              ref={inputWrapperRef}
-              className="relative w-full"
-            >
-              <PromptInput
-                onSubmit={handleSubmit}
-                className="w-full border-white/10 bg-secondary/30 transition-all duration-200 focus-within:border-white/25 focus-within:bg-secondary/40 focus-within:ring-1 focus-within:ring-white/10"
-              >
-                <PromptInputBody>
-                  <PromptInputTextarea
-                    placeholder="Pick a suggestion or ask anything about me..."
-                    disabled={isLoading}
-                    maxLength={160}
-                    minLength={3}
-                    className="text-xs text-white placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0 md:text-sm"
-                  />
-                </PromptInputBody>
-                <PromptInputFooter className="justify-end">
-                  <PromptInputTools>
-                    <button
-                      type="submit"
-                      disabled={isLoading}
-                      className="flex h-8 w-8 items-center justify-center rounded-xl bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 disabled:opacity-50"
-                    >
-                      {isLoading ? (
-                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-secondary-foreground border-t-transparent" />
-                      ) : (
-                        <Send className="h-4 w-4" />
-                      )}
-                    </button>
-                  </PromptInputTools>
-                </PromptInputFooter>
-              </PromptInput>
+            <div className="flex flex-col gap-3 border-t border-white/10 p-4">
+              {suggestionsCarousel}
+              {inputArea}
             </div>
-          </>
-        )}
-      </section>
+          </DrawerContent>
+        </Drawer>
+      )}
     </div>
   );
 };

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const update = () => setMatches(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, [query]);
+
+  return matches;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.167.1",
+        "vaul": "^1.1.2",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -9639,6 +9640,18 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.167.1",
+    "vaul": "^1.1.2",
     "zod": "^3.22.4"
   },
   "prisma": {


### PR DESCRIPTION
## Summary
- Open the expanded chatbot in a centered Radix `Dialog` on desktop (≥768px) and a vaul-based `Drawer` on mobile; collapsed trigger is unchanged.
- Messages area now fills available dialog/drawer height instead of being capped at 200px, so tall AI replies are readable without cramped scrolling.
- Fix layout shift: Radix's scroll-lock was zeroing the body's `margin-left` and adding `margin-right: 15px`, breaking the `mx-auto w-[min(95%,750px)]` centering in `app/layout.tsx`. Restored via a higher-specificity override in `app/globals.css`.
- Adds `vaul` dependency and shadcn Drawer primitive; adds `hooks/use-media-query.ts`.

## Test plan
- [ ] Desktop (≥768px): click collapsed card → centered dialog ~90vw (max 900px) / ~85vh opens with zoom+fade+slide-from-bottom
- [ ] Mobile (<768px): click collapsed card → vaul drawer slides up from bottom with grab-handle
- [ ] ESC closes both; X button closes both; backdrop click does NOT close (per spec)
- [ ] Page stays centered while dialog is open (no leftward shift)
- [ ] Send a message and verify streamed reply scrolls inside the messages area without clipping
- [ ] Click a suggestion pill while closed → dialog opens and textarea is populated/focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat interface now responds to screen size—modal dialog on desktop, bottom drawer on mobile.
  * Chat automatically opens when messages arrive.
  * Improved input suggestions with better focus management.

* **Bug Fixes**
  * Fixed centered layout behavior during scroll lock state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->