### PR TITLE
chore(skills): add pr-writer skill and restore chatbot backdrop close

### DIFF
--- a/.agents/skills/pr-writer/SKILL.md
+++ b/.agents/skills/pr-writer/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: pr-writer
+description: ALWAYS use this skill when creating or updating pull requests — never create or edit a PR directly without it. Follows Sentry conventions for PR titles, descriptions, and issue references. Trigger on any create PR, open PR, submit PR, make PR, update PR title, update PR description, edit PR, push and create PR, prepare changes for review task, or request for a PR writer.
+---
+
+# PR Writer
+
+Create pull requests following Sentry's engineering practices.
+
+**Requires**: GitHub CLI (`gh`) authenticated and available.
+
+## Prerequisites
+
+Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the `sentry-skills:commit` skill first to commit them properly.
+
+```bash
+# Check for uncommitted changes
+git status --porcelain
+```
+
+If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the `sentry-skills:commit` skill before proceeding.
+
+## Process
+
+### Step 1: Verify Branch State
+
+```bash
+# Detect the default branch — note the output for use in subsequent commands
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+```bash
+# Check current branch and status (substitute the detected branch name above for BASE)
+git status
+git log BASE..HEAD --oneline
+```
+
+Ensure:
+- All changes are committed
+- Branch is up to date with remote
+- Changes are rebased on the base branch if needed
+
+### Step 2: Analyze Changes
+
+Review what will be included in the PR:
+
+```bash
+# See all commits that will be in the PR (substitute detected branch name for BASE)
+git log BASE..HEAD
+
+# See the full diff
+git diff BASE...HEAD
+```
+
+Understand the scope and purpose of all changes before writing the description.
+
+### Step 3: Write the PR Description
+
+Use this structure for PR descriptions (ignoring any repository PR templates):
+
+```markdown
+<brief description of what the PR does>
+
+<why these changes are being made - the motivation>
+
+<alternative approaches considered, if any>
+
+<any additional context reviewers need>
+```
+
+**Do NOT include:**
+- "Test plan" sections
+- Checkbox lists of testing steps
+- Redundant summaries of the diff
+- Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and if available, reference the internal ticket (e.g. `Fixes SENTRY-1234`). PRs are typically public on open-source repos.
+
+**Do include:**
+- Clear explanation of what and why
+- Links to relevant issues or tickets
+- Context that isn't obvious from the code
+- Notes on specific areas that need careful review
+
+### Step 4: Create the PR
+
+```bash
+gh pr create --draft --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+<description body here>
+EOF
+)"
+```
+
+**Title format** follows commit conventions:
+- `feat(scope): Add new feature`
+- `fix(scope): Fix the bug`
+- `ref: Refactor something`
+
+## PR Description Examples
+
+### Feature PR
+
+```markdown
+Add Slack thread replies for alert notifications
+
+When an alert is updated or resolved, we now post a reply to the original
+Slack thread instead of creating a new message. This keeps related
+notifications grouped and reduces channel noise.
+
+Previously considered posting edits to the original message, but threading
+better preserves the timeline of events and works when the original message
+is older than Slack's edit window.
+
+Refs SENTRY-1234
+```
+
+### Bug Fix PR
+
+```markdown
+Handle null response in user API endpoint
+
+The user endpoint could return null for soft-deleted accounts, causing
+dashboard crashes when accessing user properties. This adds a null check
+and returns a proper 404 response.
+
+Found while investigating SENTRY-5678.
+
+Fixes SENTRY-5678
+```
+
+### Refactor PR
+
+```markdown
+Extract validation logic to shared module
+
+Moves duplicate validation code from the alerts, issues, and projects
+endpoints into a shared validator class. No behavior change.
+
+This prepares for adding new validation rules in SENTRY-9999 without
+duplicating logic across endpoints.
+```
+
+## Issue References
+
+Reference issues in the PR body:
+
+| Syntax | Effect |
+|--------|--------|
+| `Fixes #1234` | Closes GitHub issue on merge |
+| `Fixes SENTRY-1234` | Closes Sentry issue |
+| `Refs GH-1234` | Links without closing |
+| `Refs LINEAR-ABC-123` | Links Linear issue |
+
+## Guidelines
+
+- **One PR per feature/fix** - Don't bundle unrelated changes
+- **Keep PRs reviewable** - Smaller PRs get faster, better reviews
+- **Explain the why** - Code shows what; description explains why
+- **Mark WIP early** - Use draft PRs for early feedback
+
+## Editing Existing PRs
+
+If you need to update a PR after creation, use `gh api` instead of `gh pr edit`:
+
+```bash
+# Update PR description
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body="$(cat <<'EOF'
+Updated description here
+EOF
+)"
+
+# Update PR title
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f title='new: Title here'
+
+# Update both
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
+  -f title='new: Title' \
+  -f body='New description'
+```
+
+Note: `gh pr edit` is currently broken due to GitHub's Projects (classic) deprecation.
+
+## References
+
+- [Sentry Code Review Guidelines](https://develop.sentry.dev/engineering-practices/code-review/)
+- [Sentry Commit Messages](https://develop.sentry.dev/engineering-practices/commit-messages/)

--- a/.claude/skills/pr-writer/SKILL.md
+++ b/.claude/skills/pr-writer/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: pr-writer
+description: ALWAYS use this skill when creating or updating pull requests — never create or edit a PR directly without it. Follows Sentry conventions for PR titles, descriptions, and issue references. Trigger on any create PR, open PR, submit PR, make PR, update PR title, update PR description, edit PR, push and create PR, prepare changes for review task, or request for a PR writer.
+---
+
+# PR Writer
+
+Create pull requests following Sentry's engineering practices.
+
+**Requires**: GitHub CLI (`gh`) authenticated and available.
+
+## Prerequisites
+
+Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the `sentry-skills:commit` skill first to commit them properly.
+
+```bash
+# Check for uncommitted changes
+git status --porcelain
+```
+
+If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the `sentry-skills:commit` skill before proceeding.
+
+## Process
+
+### Step 1: Verify Branch State
+
+```bash
+# Detect the default branch — note the output for use in subsequent commands
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+```bash
+# Check current branch and status (substitute the detected branch name above for BASE)
+git status
+git log BASE..HEAD --oneline
+```
+
+Ensure:
+- All changes are committed
+- Branch is up to date with remote
+- Changes are rebased on the base branch if needed
+
+### Step 2: Analyze Changes
+
+Review what will be included in the PR:
+
+```bash
+# See all commits that will be in the PR (substitute detected branch name for BASE)
+git log BASE..HEAD
+
+# See the full diff
+git diff BASE...HEAD
+```
+
+Understand the scope and purpose of all changes before writing the description.
+
+### Step 3: Write the PR Description
+
+Use this structure for PR descriptions (ignoring any repository PR templates):
+
+```markdown
+<brief description of what the PR does>
+
+<why these changes are being made - the motivation>
+
+<alternative approaches considered, if any>
+
+<any additional context reviewers need>
+```
+
+**Do NOT include:**
+- "Test plan" sections
+- Checkbox lists of testing steps
+- Redundant summaries of the diff
+- Customer data — customer/org names, user emails, support ticket contents, or PII. Describe the technical symptom, not who hit it, and if available, reference the internal ticket (e.g. `Fixes SENTRY-1234`). PRs are typically public on open-source repos.
+
+**Do include:**
+- Clear explanation of what and why
+- Links to relevant issues or tickets
+- Context that isn't obvious from the code
+- Notes on specific areas that need careful review
+
+### Step 4: Create the PR
+
+```bash
+gh pr create --draft --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+<description body here>
+EOF
+)"
+```
+
+**Title format** follows commit conventions:
+- `feat(scope): Add new feature`
+- `fix(scope): Fix the bug`
+- `ref: Refactor something`
+
+## PR Description Examples
+
+### Feature PR
+
+```markdown
+Add Slack thread replies for alert notifications
+
+When an alert is updated or resolved, we now post a reply to the original
+Slack thread instead of creating a new message. This keeps related
+notifications grouped and reduces channel noise.
+
+Previously considered posting edits to the original message, but threading
+better preserves the timeline of events and works when the original message
+is older than Slack's edit window.
+
+Refs SENTRY-1234
+```
+
+### Bug Fix PR
+
+```markdown
+Handle null response in user API endpoint
+
+The user endpoint could return null for soft-deleted accounts, causing
+dashboard crashes when accessing user properties. This adds a null check
+and returns a proper 404 response.
+
+Found while investigating SENTRY-5678.
+
+Fixes SENTRY-5678
+```
+
+### Refactor PR
+
+```markdown
+Extract validation logic to shared module
+
+Moves duplicate validation code from the alerts, issues, and projects
+endpoints into a shared validator class. No behavior change.
+
+This prepares for adding new validation rules in SENTRY-9999 without
+duplicating logic across endpoints.
+```
+
+## Issue References
+
+Reference issues in the PR body:
+
+| Syntax | Effect |
+|--------|--------|
+| `Fixes #1234` | Closes GitHub issue on merge |
+| `Fixes SENTRY-1234` | Closes Sentry issue |
+| `Refs GH-1234` | Links without closing |
+| `Refs LINEAR-ABC-123` | Links Linear issue |
+
+## Guidelines
+
+- **One PR per feature/fix** - Don't bundle unrelated changes
+- **Keep PRs reviewable** - Smaller PRs get faster, better reviews
+- **Explain the why** - Code shows what; description explains why
+- **Mark WIP early** - Use draft PRs for early feedback
+
+## Editing Existing PRs
+
+If you need to update a PR after creation, use `gh api` instead of `gh pr edit`:
+
+```bash
+# Update PR description
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body="$(cat <<'EOF'
+Updated description here
+EOF
+)"
+
+# Update PR title
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f title='new: Title here'
+
+# Update both
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
+  -f title='new: Title' \
+  -f body='New description'
+```
+
+Note: `gh pr edit` is currently broken due to GitHub's Projects (classic) deprecation.
+
+## References
+
+- [Sentry Code Review Guidelines](https://develop.sentry.dev/engineering-practices/code-review/)
+- [Sentry Commit Messages](https://develop.sentry.dev/engineering-practices/commit-messages/)

--- a/components/chat-bot.tsx
+++ b/components/chat-bot.tsx
@@ -301,7 +301,6 @@ const ChatBot = () => {
           <DialogPrimitive.Portal>
             <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
             <DialogPrimitive.Content
-              onPointerDownOutside={(e) => e.preventDefault()}
               className={cn(
                 "fixed left-1/2 top-1/2 z-50 flex -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden",
                 "h-[85vh] w-[min(90vw,900px)] rounded-2xl",
@@ -356,7 +355,6 @@ const ChatBot = () => {
           shouldScaleBackground={false}
         >
           <DrawerContent
-            onPointerDownOutside={(e) => e.preventDefault()}
             className="flex h-[90dvh] max-h-[90dvh] flex-col overflow-hidden border-white/10 bg-background/95 backdrop-blur-md"
           >
             <DrawerHeader className="mt-2 flex shrink-0 flex-row items-center justify-between border-b border-white/10 px-4 py-3 text-left">

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -21,6 +21,11 @@
       "sourceType": "github",
       "computedHash": "daf64ca15f4fa081a6747766db538e2dbd1131725ed4fcdd3d538dc62c7035ba"
     },
+    "pr-writer": {
+      "source": "getsentry/skills",
+      "sourceType": "github",
+      "computedHash": "f5c35b0ebd8942bf22474066032f3ca1232f8bc9100addae26208c6bb03fc2e3"
+    },
     "shadcn": {
       "source": "shadcn/ui",
       "sourceType": "github",


### PR DESCRIPTION
Add the `pr-writer` skill to both local skill directories and record it in `skills-lock.json`, and restore the default outside-click behavior for the chatbot dialog and mobile drawer.

The skill files keep the local Codex and Claude skill setups in sync so PR drafting guidance is available in both places. The chatbot change removes the explicit outside-pointer prevention so clicking the backdrop dismisses the overlay again, which matches expected dialog behavior.

I considered keeping the backdrop locked, but that made the chatbot feel harder to dismiss and worked against the standard modal interaction pattern. The skill install also could have been tracked in only one directory, but this repo currently mirrors the skill in both locations.

`master` already includes the earlier chatbot regression fix from PR #15, so this follow-up only contains the skill install and the backdrop-dismiss behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pr-writer skill for automated pull request creation and management workflows

* **Improvements**
  * Enhanced chat interface to allow natural pointer interactions outside the chat overlay, improving responsiveness and user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->